### PR TITLE
Initialize dll in UdpListener and pass dll path as a parameter

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,3 +1,5 @@
+import argparse
+
 from real_time_process import UdpListener, DataProcessor
 from radar_config import SerialConfig
 from radar_config import DCA1000Config
@@ -339,6 +341,11 @@ def application():
 
 
 if __name__ == '__main__':
+    # parse arguments
+    parser = argparse.ArgumentParser(prog='RadarStream')
+    parser.add_argument('--dll-path', default='libs/UDPCAPTUREADCRAWDATA.dll', help='path to the dll file')
+    args = parser.parse_args()
+
     # Queue for access data
     BinData = Queue() # 原始数据队列
 
@@ -363,8 +370,7 @@ if __name__ == '__main__':
     # config DCA1000 to receive bin data
     dca1000_cfg = DCA1000Config('DCA1000Config',config_address = ('192.168.33.30', 4096),
                                                 FPGA_address_cfg=('192.168.33.180', 4096))
-
-    collector = UdpListener('Listener', BinData, frame_length)
+    collector = UdpListener('Listener', BinData, frame_length, args.dll_path)
     processor = DataProcessor('Processor', radar_config, BinData, RTIData, DTIData, 
                                              RDIData, RAIData, REIData)
     collector.start()

--- a/real_time_process.py
+++ b/real_time_process.py
@@ -4,10 +4,6 @@ import DSP
 from dsp.utils import Window
 from ctypes import *
 
-# 这一块处理需要手动修改代码很不友好，希望有人能pull  request
-dll = cdll.LoadLibrary('realtimeSystem/libs/UDPCAPTUREADCRAWDATA.dll')
-# dll = cdll.LoadLibrary('realtimeSystem/dll/libtest.so')
-
 a = np.zeros(1).astype(np.int)
 # 内存大小至少是frame_length的两倍 ，双缓冲区
 # 98304 的计算方法是例如你的配置如下：
@@ -26,14 +22,15 @@ b_ctypes_ptr = cast(b.ctypes.data, POINTER(c_short))
 
 
 class UdpListener(th.Thread):
-    def __init__(self, name, bin_data, data_frame_length):
+    def __init__(self, name, bin_data, data_frame_length, dll_file_path):
         th.Thread.__init__(self, name=name)
         self.bin_data = bin_data
         self.frame_length = data_frame_length
+        self.dll = cdll.LoadLibrary(dll_file_path)
 
     def run(self):
         global a_ctypes_ptr, b_ctypes_ptr
-        dll.captureudp(a_ctypes_ptr, b_ctypes_ptr, self.frame_length)
+        self.dll.captureudp(a_ctypes_ptr, b_ctypes_ptr, self.frame_length)
 
 
 class DataProcessor(th.Thread):


### PR DESCRIPTION
1. Since dll is only used in `UdpListener`, we can make it a member variable of the class
2. Then the path of dll file can be added as a parameter
3. This parameter can be given in `main.py` through the argument parser, so that we don't need to modify the code to update the path every time.